### PR TITLE
topic/issue_5: パスワードをハッシュ化して扱えるようにした

### DIFF
--- a/src/main/java/page/clapandwhistle/uam/infrastructure/AggregateRepository/User/UserAggregateRepository.java
+++ b/src/main/java/page/clapandwhistle/uam/infrastructure/AggregateRepository/User/UserAggregateRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import page.clapandwhistle.uam.infrastructure.AggregateRepository.Exception.RegistrationProcessFailedException;
@@ -97,8 +98,9 @@ final public class UserAggregateRepository implements UserAggregateRepositoryInt
         throw new PasswordIsNotMatchException();
     }
 
-    private boolean isPasswordMatch(String password, UserAccountBase userAccountBase) {
-        // TODO: ハッシュ化したパスワードとのマッチング
-        return password.equals(userAccountBase.getPassword());
+    private boolean isPasswordMatch(String input, UserAccountBase userAccountBase) {
+        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        String savedDigest = userAccountBase.getPassword();
+        return passwordEncoder.matches(input, savedDigest);
     }
 }

--- a/src/main/java/page/clapandwhistle/uam/infrastructure/AggregateRepository/User/UserAggregateRepository.java
+++ b/src/main/java/page/clapandwhistle/uam/infrastructure/AggregateRepository/User/UserAggregateRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import page.clapandwhistle.uam.infrastructure.AggregateRepository.Exception.RegistrationProcessFailedException;
@@ -68,7 +69,8 @@ final public class UserAggregateRepository implements UserAggregateRepositoryInt
 
         entityUserAccountBase.setEmail(user.email());
         // TODO: パスワード保存処理の分離（setPasswordは「アカウント作成」と「パスワード変更/再発行」のUseCaseだけ行うようにする）
-        entityUserAccountBase.setPassword(user.password());
+        BCryptPasswordEncoder pwEncoder = new BCryptPasswordEncoder();
+        entityUserAccountBase.setPassword(pwEncoder.encode(user.password()));
         entityUserAccountBase.setAccountStatus(user.accountStatus().raw());
         entityUserAccountProfile.setFullName(user.fullName());
         entityUserAccountProfile.setBirthDateStr(user.birthDateStr());

--- a/src/main/java/page/clapandwhistle/uam/infrastructure/LoadDatabase.java
+++ b/src/main/java/page/clapandwhistle/uam/infrastructure/LoadDatabase.java
@@ -27,7 +27,10 @@ public class LoadDatabase {
             log.info("CommandLineRunner::initDatabase: " + profile);
             if (profile.equals("default") || profile.equals("testing")) {
                 /* Unitテスト用のデータを登録する */
-                UserAccountBase userAccountBase = new UserAccountBase("hoge01@example.local", "hoge01TEST");
+                UserAccountBase userAccountBase = new UserAccountBase(
+                        "hoge01@example.local",
+                        "$2a$10$rKNNt5Np1tRUx3vArlZwJ.jTgNspEfD/hLyZjLPeMAX5N0nhbvb7G" // "hoge01TEST"
+                );
                 userAccountBase.setUserAccountProfile(new UserAccountProfile("hoge01", "20000410"));
                 log.info("  Preloading " + userAccountBaseRepos.save(userAccountBase));
             } else {

--- a/src/profiles/development/resources/db/migration/V1_0_2__Add_user.sql
+++ b/src/profiles/development/resources/db/migration/V1_0_2__Add_user.sql
@@ -1,2 +1,6 @@
-insert into user_account_base (account_status, email, password, user_account_profile_id) values (0, 'hoge01@example.local', 'hoge01TEST', 1);
+insert into user_account_base
+    (account_status, email, password, user_account_profile_id)
+  values
+    -- password = 'hoge01TEST'
+    (0, 'hoge01@example.local', '$2a$10$rKNNt5Np1tRUx3vArlZwJ.jTgNspEfD/hLyZjLPeMAX5N0nhbvb7G', 1);
 insert into user_account_profile (id, birth_date_str, full_name) values (1, '20000410', 'hoge01');


### PR DESCRIPTION
# 関連する課題

- #5

# 実装内容

- インフラ層の実装クラスで「パスワードの保存時」および「パスワード照合時」の処理をハッシュ化に対応させた。
    - そのため、Unitテストのテストコードに対する変更はありません。
